### PR TITLE
ci: Add GitHub Actions workflow for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+# .github/workflows/deploy.yml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to allow peaceiris/actions-gh-pages to push to gh-pages
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy to gh-pages from @ ${{ github.sha }}'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy to GitHub Pages](https://github.com/jonmrjr/antidojt/actions/workflows/deploy.yml/badge.svg)](https://github.com/jonmrjr/antidojt/actions/workflows/deploy.yml)
+
 # Claude Artifact Runner
 
 ## Table of Contents


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the deployment of the application to GitHub Pages.

The workflow is defined in `.github/workflows/deploy.yml` and configured to:
- Trigger on every push to the `main` branch.
- Check out the code.
- Set up Node.js (version 20.x) and cache npm dependencies.
- Install project dependencies using `npm ci`.
- Build the project using `npm run build`.
- Deploy the contents of the `dist` directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages@v4` action.

Additionally, a status badge for this workflow has been added to the `README.md` file to provide a visual indicator of the deployment status.

After these changes are pushed to the `main` branch, the deployment process will be fully automated.